### PR TITLE
Anpassen von Referenzen im Implementation Guide

### DIFF
--- a/Resources/fsh-generated/resources/MedicationRequest-Example-Initial-Medication-Request.json
+++ b/Resources/fsh-generated/resources/MedicationRequest-Example-Initial-Medication-Request.json
@@ -1,0 +1,42 @@
+{
+  "resourceType": "MedicationRequest",
+  "id": "Example-Initial-Medication-Request",
+  "meta": {
+    "profile": [
+      "https://gematik.de/fhir/erp-servicerequest/StructureDefinition/erp-service-request-medication-request"
+    ]
+  },
+  "extension": [
+    {
+      "valueIdentifier": {
+        "system": "https://gematik.de/fhir/erp/NamingSystem/GEM_ERP_NS_PrescriptionId",
+        "value": "160.100.000.000.001.36"
+      },
+      "url": "https://gematik.de/fhir/erp-servicerequest/StructureDefinition/prescription-id-ex"
+    }
+  ],
+  "dispenseRequest": {
+    "quantity": {
+      "system": "http://unitsofmeasure.org",
+      "code": "{Package}",
+      "value": 1
+    }
+  },
+  "status": "active",
+  "intent": "order",
+  "medicationReference": {
+    "reference": "Medication/Example-Initial-Medication"
+  },
+  "subject": {
+    "reference": "Patient/Example-Patient"
+  },
+  "authoredOn": "2022-05-20",
+  "dosageInstruction": [
+    {
+      "text": "2mal tägl. 5ml"
+    }
+  ],
+  "substitution": {
+    "allowedBoolean": true
+  }
+}

--- a/Resources/fsh-generated/resources/MessageHeader-UC1-HealthCareService-to-Practitioner-MessageHeader.json
+++ b/Resources/fsh-generated/resources/MessageHeader-UC1-HealthCareService-to-Practitioner-MessageHeader.json
@@ -1,0 +1,40 @@
+{
+  "resourceType": "MessageHeader",
+  "id": "UC1-HealthCareService-to-Practitioner-MessageHeader",
+  "meta": {
+    "profile": [
+      "https://gematik.de/fhir/erp-servicerequest/StructureDefinition/erp-service-request-request-header"
+    ]
+  },
+  "focus": [
+    {
+      "reference": "ServiceRequest/UC1-Initial-Prescription-Request"
+    }
+  ],
+  "sender": {
+    "identifier": {
+      "system": "http://gematik.de/fhir/sid/KIM-Adresse",
+      "value": "pflegeheim.immergrün.arzt@sana-pflegeheime.kim.telematik"
+    },
+    "display": "Pflegeheim Immergrün"
+  },
+  "destination": [
+    {
+      "receiver": {
+        "identifier": {
+          "system": "http://gematik.de/fhir/sid/KIM-Adresse",
+          "value": "hans@ytopp-gluecklich.kim.telematik"
+        },
+        "display": "Praxis Hans Topp-Glücklich"
+      },
+      "endpoint": "klaus@test.de"
+    }
+  ],
+  "source": {
+    "endpoint": "http://test-pflegeheim.de"
+  },
+  "eventCoding": {
+    "code": "eRezept_Rezeptanforderung;Rezeptanfrage",
+    "system": "https://gematik.de/fhir/atf/CodeSystem/service-identifier-cs"
+  }
+}

--- a/Resources/fsh-generated/resources/Observation-Medication-Runs-Out-Example-Quantity.json
+++ b/Resources/fsh-generated/resources/Observation-Medication-Runs-Out-Example-Quantity.json
@@ -1,0 +1,25 @@
+{
+  "resourceType": "Observation",
+  "id": "Medication-Runs-Out-Example-Quantity",
+  "meta": {
+    "profile": [
+      "https://gematik.de/fhir/erp-servicerequest/StructureDefinition/erp-service-request-remaining-medication"
+    ]
+  },
+  "status": "final",
+  "subject": {
+    "reference": "Patient/Example-Patient"
+  },
+  "code": {
+    "coding": [
+      {
+        "code": "range-of-medication",
+        "system": "https://gematik.de/fhir/erp-servicerequest/CodeSystem/medication-observation-cs"
+      }
+    ]
+  },
+  "valueQuantity": {
+    "value": 7,
+    "unit": "stk"
+  }
+}

--- a/Resources/fsh-generated/resources/Observation-Medication-Runs-Out-Example-dateTime.json
+++ b/Resources/fsh-generated/resources/Observation-Medication-Runs-Out-Example-dateTime.json
@@ -1,0 +1,22 @@
+{
+  "resourceType": "Observation",
+  "id": "Medication-Runs-Out-Example-dateTime",
+  "meta": {
+    "profile": [
+      "https://gematik.de/fhir/erp-servicerequest/StructureDefinition/erp-service-request-remaining-medication"
+    ]
+  },
+  "status": "final",
+  "subject": {
+    "reference": "Patient/Example-Patient"
+  },
+  "code": {
+    "coding": [
+      {
+        "code": "range-of-medication",
+        "system": "https://gematik.de/fhir/erp-servicerequest/CodeSystem/medication-observation-cs"
+      }
+    ]
+  },
+  "valueDateTime": "2023-01-31"
+}

--- a/Resources/fsh-generated/resources/Organization-Example-HealthCareService-Organization.json
+++ b/Resources/fsh-generated/resources/Organization-Example-HealthCareService-Organization.json
@@ -1,0 +1,78 @@
+{
+  "resourceType": "Organization",
+  "id": "Example-HealthCareService-Organization",
+  "meta": {
+    "profile": [
+      "https://gematik.de/fhir/erp-servicerequest/StructureDefinition/erp-service-request-organization"
+    ]
+  },
+  "identifier": [
+    {
+      "type": {
+        "coding": [
+          {
+            "code": "kim-2.0",
+            "system": "https://gematik.de/fhir/directory/CodeSystem/EndpointDirectoryConnectionType"
+          }
+        ]
+      },
+      "system": "http://gematik.de/fhir/sid/KIM-Adresse",
+      "value": "pflegeheim.immergrün.arzt@sana-pflegeheime.kim.telematik"
+    },
+    {
+      "type": {
+        "coding": [
+          {
+            "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
+            "code": "PRN"
+          }
+        ]
+      },
+      "system": "https://gematik.de/fhir/sid/telematik-id",
+      "value": "1-031234567"
+    },
+    {
+      "type": {
+        "coding": [
+          {
+            "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
+            "code": "BSNR"
+          }
+        ]
+      },
+      "system": "https://fhir.kbv.de/NamingSystem/KBV_NS_Base_BSNR",
+      "value": "031234567"
+    }
+  ],
+  "address": [
+    {
+      "type": "both",
+      "line": [
+        "Musterstr. 2"
+      ],
+      "_line": [
+        {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/iso21090-ADXP-houseNumber",
+              "valueString": "2"
+            },
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/iso21090-ADXP-streetName",
+              "valueString": "Musterstr."
+            }
+          ]
+        }
+      ],
+      "city": "Berlin",
+      "postalCode": "10623"
+    }
+  ],
+  "name": "Pflegeheim Immergrün",
+  "telecom": [
+    {
+      "system": "phone",
+      "value": "0301234567"
+    }
+  ]
+}

--- a/Resources/input/fsh/examples/UC1/UC1_MessageHeader.fsh
+++ b/Resources/input/fsh/examples/UC1/UC1_MessageHeader.fsh
@@ -1,6 +1,6 @@
 Instance: UC1-HealthCareService-to-Practitioner-MessageHeader
 InstanceOf: ERPServiceRequestRequestHeader
-Usage: #inline
+Usage: #example
 Title: "HealthCareService-to-Practitioner-MessageHeader"
 Description: "Message Header from HealthCareService to Practitioner"
 * insert HealthCareService-to-Practitioner(UC1-Initial-Prescription-Request)

--- a/Resources/input/fsh/profiles/4_MedicationRequest.fsh
+++ b/Resources/input/fsh/profiles/4_MedicationRequest.fsh
@@ -79,7 +79,7 @@ Das empfangende System MUSS bei vorliegen dieser ID in der Lage sein nach der vo
 
 Instance: Example-Initial-Medication-Request
 InstanceOf: ERPServiceRequestMedicationRequest
-Usage: #inline
+Usage: #example
 * extension[PriorPrescriptionID].valueIdentifier
   * system = "https://gematik.de/fhir/erp/NamingSystem/GEM_ERP_NS_PrescriptionId"
   * value = "160.100.000.000.001.36"

--- a/Resources/input/fsh/profiles/7_ReminingObservation.fsh
+++ b/Resources/input/fsh/profiles/7_ReminingObservation.fsh
@@ -22,7 +22,7 @@ Description: "Diese Observation beschreibt wie lange oder wie viel einer Medikat
 
 Instance: Medication-Runs-Out-Example-dateTime
 InstanceOf: ERPServiceRequestRemainingMedication
-Usage: #inline
+Usage: #example
 Title: "Medication-Runs-Out-Example-dateTime"
 Description: "Simple example to show that Medication will last until dateTime"
 * subject = Reference(Example-Patient)
@@ -31,7 +31,7 @@ Description: "Simple example to show that Medication will last until dateTime"
 
 Instance: Medication-Runs-Out-Example-Quantity
 InstanceOf: ERPServiceRequestRemainingMedication
-Usage: #inline
+Usage: #example
 Title: "Medication-Runs-Out-Example-Quantity"
 Description: "Simple example to show how many pieces of medication are left"
 * subject = Reference(Example-Patient)

--- a/Resources/input/fsh/profiles/8_Organization.fsh
+++ b/Resources/input/fsh/profiles/8_Organization.fsh
@@ -17,7 +17,7 @@ Description: "Organisation die genutzt werden kann, um eine KIM-Addresse mit anz
 
 Instance: Example-HealthCareService-Organization
 InstanceOf: ERPServiceRequestOrganization
-Usage: #inline
+Usage: #example
 * identifier[Telematik-ID].type = http://terminology.hl7.org/CodeSystem/v2-0203#PRN
 * identifier[Telematik-ID].system = "https://gematik.de/fhir/sid/telematik-id"
 * identifier[Telematik-ID].value = "1-031234567"

--- a/guides/ig-rezeptanforderung/Home/Datenobjekte/Dispense_ServiceRequest/5_Beispiel.page.md
+++ b/guides/ig-rezeptanforderung/Home/Datenobjekte/Dispense_ServiceRequest/5_Beispiel.page.md
@@ -2,4 +2,4 @@
 
 Valides Beispiel einer Verordnungsanfrage:
 
-{{json:UC1-Initial-Dispense-Request}}
+{{json:UC1-3-Dispense-Request-To-Pharmacy}}

--- a/guides/ig-rezeptanforderung/Home/Einfuehrung.page.md
+++ b/guides/ig-rezeptanforderung/Home/Einfuehrung.page.md
@@ -68,10 +68,10 @@ Beispielinstanzen sind im [Simplifier-Projekt](https://simplifier.net/erezept-me
 
 Folgende UseCases sind mit entsprechenden Beispielen beschrieben:
 
-UC1: Pflegeeinrichtung -> Arzt -> Pflegeeinrichtung -> Apotheke
-UC2: Pflegeeinrichtung -> Arzt -> Apotheke -> Pflegeeinrichtung
-UC3: Pflegeeinrichtung -> Arzt -> Pflegeeinrichtung (Patient geht selbst zur Apotheke)
-UC4(parenterale Zubereitung): Apotheke -> Arzt -> Apotheke
+* UC1: Pflegeeinrichtung -> Arzt -> Pflegeeinrichtung -> Apotheke
+* UC2: Pflegeeinrichtung -> Arzt -> Apotheke -> Pflegeeinrichtung
+* UC3: Pflegeeinrichtung -> Arzt -> Pflegeeinrichtung (Patient geht selbst zur Apotheke)
+* UC4(parenterale Zubereitung): Apotheke -> Arzt -> Apotheke
 
 Die Beispiele tragen jeweils das Präfix zum entsprechenden UseCase und der entsprechenden Sequenz. Bsp: UC1-3-* ist ein Beispiel, was UC1 zugeordnet ist und den dritten Schritt in der Abfolge entspricht.
 Für UC1 gibt es auch Storno Beispiele.


### PR DESCRIPTION
Einige Referenzen waren noch falsch und wurden nun korrekt gesetzt.

Einige Beispiele konnten nicht gerendert werden, da in fsh die Instanz auf "#inline" gestellt war, damit wurde die Datei nicht erstellt. Das wurde nun auf "#example" geändert. Die Inhalte sollten nun korrekt dargestellt werden