### PR TITLE
Ordner für Beispiele anlegen

### DIFF
--- a/examples/rezeptanforderung/dispense-request/Bundle-UC1-3-Dispense-Request-To-Pharmacy.json
+++ b/examples/rezeptanforderung/dispense-request/Bundle-UC1-3-Dispense-Request-To-Pharmacy.json
@@ -1,0 +1,185 @@
+{
+  "resourceType": "Bundle",
+  "id": "UC1-3-Dispense-Request-To-Pharmacy",
+  "meta": {
+    "profile": [
+      "https://gematik.de/fhir/erp-servicerequest/StructureDefinition/erp-service-request-message-container"
+    ]
+  },
+  "type": "message",
+  "identifier": {
+    "system": "urn:ietf:rfc:3986",
+    "value": "urn:uuid:c80f6c55-92f8-4518-ba66-cb193da09336"
+  },
+  "timestamp": "2023-02-01T13:28:17.239+02:00",
+  "entry": [
+    {
+      "fullUrl": "http://erp-servicerequest-test.de/MessageHeader/UC1-HealthCareService-to-Pharmacy-MessageHeader",
+      "resource": {
+        "resourceType": "MessageHeader",
+        "id": "UC1-HealthCareService-to-Pharmacy-MessageHeader",
+        "meta": {
+          "profile": [
+            "https://gematik.de/fhir/erp-servicerequest/StructureDefinition/erp-service-request-request-header"
+          ]
+        },
+        "focus": [
+          {
+            "reference": "ServiceRequest/UC1-Initial-Dispense-Request"
+          }
+        ],
+        "sender": {
+          "identifier": {
+            "system": "http://gematik.de/fhir/sid/KIM-Adresse",
+            "value": "pflegeheim.immergrün.arzt@sana-pflegeheime.kim.telematik"
+          },
+          "display": "Pflegeheim Immergrün"
+        },
+        "destination": [
+          {
+            "receiver": {
+              "identifier": {
+                "system": "http://gematik.de/fhir/sid/KIM-Adresse",
+                "value": "hans@ytopp-gluecklich.kim.telematik"
+              },
+              "display": "Praxis Hans Topp-Glücklich"
+            },
+            "endpoint": "klaus@test.de"
+          }
+        ],
+        "source": {
+          "name": "HealthCare-Source",
+          "software": "HealthCare-Software",
+          "version": "1.0.0",
+          "contact": {
+            "system": "email",
+            "value": "info@healthcare.email"
+          },
+          "endpoint": "http://healthcare.endpoint"
+        },
+        "eventCoding": {
+          "code": "eRezept_Rezeptanforderung;Abgabeanfrage",
+          "system": "https://gematik.de/fhir/atf/CodeSystem/service-identifier-cs"
+        }
+      }
+    },
+    {
+      "fullUrl": "http://erp-servicerequest-test.de/Patient/Example-Patient",
+      "resource": {
+        "resourceType": "Patient",
+        "id": "Example-Patient",
+        "meta": {
+          "profile": [
+            "https://fhir.kbv.de/StructureDefinition/KBV_PR_FOR_Patient|1.1.0"
+          ]
+        },
+        "identifier": [
+          {
+            "type": {
+              "coding": [
+                {
+                  "system": "http://fhir.de/CodeSystem/identifier-type-de-basis",
+                  "code": "GKV"
+                }
+              ]
+            },
+            "system": "http://fhir.de/sid/gkv/kvid-10",
+            "value": "X234567890"
+          }
+        ],
+        "name": [
+          {
+            "use": "official",
+            "family": "Königsstein",
+            "_family": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/humanname-own-name",
+                  "valueString": "Königsstein"
+                }
+              ]
+            },
+            "given": [
+              "Ludger"
+            ]
+          }
+        ],
+        "address": [
+          {
+            "type": "both",
+            "line": [
+              "Musterstr. 1"
+            ],
+            "_line": [
+              {
+                "extension": [
+                  {
+                    "url": "http://hl7.org/fhir/StructureDefinition/iso21090-ADXP-houseNumber",
+                    "valueString": "1"
+                  },
+                  {
+                    "url": "http://hl7.org/fhir/StructureDefinition/iso21090-ADXP-streetName",
+                    "valueString": "Musterstr."
+                  }
+                ]
+              }
+            ],
+            "city": "Berlin",
+            "postalCode": "10623"
+          }
+        ],
+        "birthDate": "1935-06-22"
+      }
+    },
+    {
+      "fullUrl": "http://erp-servicerequest-test.de/ServiceRequest/UC1-Initial-Dispense-Request",
+      "resource": {
+        "resourceType": "ServiceRequest",
+        "id": "UC1-Initial-Dispense-Request",
+        "meta": {
+          "profile": [
+            "https://gematik.de/fhir/erp-servicerequest/StructureDefinition/erp-service-request-dispense-request"
+          ]
+        },
+        "intent": "filler-order",
+        "requisition": {
+          "system": "https://gematik.de/fhir/erp-servicerequest/sid/NamingSystemProcedureIdentifier",
+          "value": "GroupID-UC1"
+        },
+        "extension": [
+          {
+            "valueIdentifier": {
+              "system": "https://gematik.de/fhir/erp/sid/NamingSystemEPrescriptionToken",
+              "value": "Task/160.100.000.000.002.36/$accept?ac=777bea0e13cc9c42ceec14aec3ddee2263325dc2c6c699db115f58fe423607ea"
+            },
+            "url": "https://gematik.de/fhir/erp-servicerequest/StructureDefinition/eprescription-token-ex"
+          }
+        ],
+        "code": {
+          "coding": [
+            {
+              "code": "dispense-request",
+              "system": "https://gematik.de/fhir/erp-servicerequest/CodeSystem/service-request-type-cs"
+            }
+          ]
+        },
+        "identifier": [
+          {
+            "system": "https://gematik.de/fhir/erp-servicerequest/sid/NamingSystemRequestIdentifier",
+            "value": "2"
+          },
+          {
+            "system": "https://gematik.de/fhir/erp-servicerequest/sid/NamingSystemPreDisIdentifier",
+            "value": "PreDis-1"
+          }
+        ],
+        "status": "active",
+        "subject": {
+          "reference": "Patient/Example-Patient"
+        },
+        "occurrenceDateTime": "2023-02-01",
+        "authoredOn": "2023-02-01"
+      }
+    }
+  ]
+}

--- a/examples/rezeptanforderung/prescription-request/Bundle-UC1-1-Prescription-Request-To-Prescriber.json
+++ b/examples/rezeptanforderung/prescription-request/Bundle-UC1-1-Prescription-Request-To-Prescriber.json
@@ -1,0 +1,463 @@
+{
+  "resourceType": "Bundle",
+  "id": "UC1-1-Prescription-Request-To-Prescriber",
+  "meta": {
+    "profile": [
+      "https://gematik.de/fhir/erp-servicerequest/StructureDefinition/erp-service-request-message-container"
+    ]
+  },
+  "type": "message",
+  "identifier": {
+    "system": "urn:ietf:rfc:3986",
+    "value": "urn:uuid:29888885-6639-481c-934e-4b7b51745084"
+  },
+  "timestamp": "2015-02-07T13:28:17.239+02:00",
+  "entry": [
+    {
+      "fullUrl": "http://erp-servicerequest-test.de/MessageHeader/UC1-HealthCareService-to-Practitioner-MessageHeader",
+      "resource": {
+        "resourceType": "MessageHeader",
+        "id": "UC1-HealthCareService-to-Practitioner-MessageHeader",
+        "meta": {
+          "profile": [
+            "https://gematik.de/fhir/erp-servicerequest/StructureDefinition/erp-service-request-request-header"
+          ]
+        },
+        "focus": [
+          {
+            "reference": "ServiceRequest/UC1-Initial-Prescription-Request"
+          }
+        ],
+        "sender": {
+          "identifier": {
+            "system": "http://gematik.de/fhir/sid/KIM-Adresse",
+            "value": "pflegeheim.immergrün.arzt@sana-pflegeheime.kim.telematik"
+          },
+          "display": "Pflegeheim Immergrün"
+        },
+        "destination": [
+          {
+            "receiver": {
+              "identifier": {
+                "system": "http://gematik.de/fhir/sid/KIM-Adresse",
+                "value": "hans@ytopp-gluecklich.kim.telematik"
+              },
+              "display": "Praxis Hans Topp-Glücklich"
+            },
+            "endpoint": "klaus@test.de"
+          }
+        ],
+        "source": {
+          "name": "HealthCare-Source",
+          "software": "HealthCare-Software",
+          "version": "1.0.0",
+          "contact": {
+            "system": "email",
+            "value": "info@healthcare.email"
+          },
+          "endpoint": "http://healthcare.endpoint"
+        },
+        "eventCoding": {
+          "code": "eRezept_Rezeptanforderung;Rezeptanfrage",
+          "system": "https://gematik.de/fhir/atf/CodeSystem/service-identifier-cs"
+        }
+      }
+    },
+    {
+      "fullUrl": "http://erp-servicerequest-test.de/ServiceRequest/UC1-Initial-Prescription-Request",
+      "resource": {
+        "resourceType": "ServiceRequest",
+        "id": "UC1-Initial-Prescription-Request",
+        "meta": {
+          "profile": [
+            "https://gematik.de/fhir/erp-servicerequest/StructureDefinition/erp-service-request-prescription-request"
+          ]
+        },
+        "intent": "order",
+        "requisition": {
+          "system": "https://gematik.de/fhir/erp-servicerequest/sid/NamingSystemProcedureIdentifier",
+          "value": "GroupID-UC1"
+        },
+        "code": {
+          "coding": [
+            {
+              "code": "prescription-request",
+              "system": "https://gematik.de/fhir/erp-servicerequest/CodeSystem/service-request-type-cs"
+            }
+          ]
+        },
+        "identifier": [
+          {
+            "system": "https://gematik.de/fhir/erp-servicerequest/sid/NamingSystemRequestIdentifier",
+            "value": "1"
+          },
+          {
+            "system": "https://gematik.de/fhir/erp-servicerequest/sid/NamingSystemPreDisIdentifier",
+            "value": "PreDis-1"
+          }
+        ],
+        "basedOn": [
+          {
+            "reference": "MedicationRequest/Example-Initial-Medication-Request"
+          }
+        ],
+        "status": "active",
+        "subject": {
+          "reference": "Patient/Example-Patient"
+        },
+        "orderDetail": [
+          {
+            "coding": [
+              {
+                "code": "return-to-requester",
+                "system": "https://gematik.de/fhir/erp-servicerequest/CodeSystem/prescription-fullfillment-type-cs"
+              }
+            ]
+          }
+        ],
+        "occurrenceDateTime": "2023-02-01",
+        "authoredOn": "2023-01-27",
+        "requester": {
+          "reference": "Organization/Example-HealthCareService-Organization"
+        },
+        "performer": [
+          {
+            "identifier": {
+              "system": "http://gematik.de/fhir/sid/KIM-Adresse",
+              "value": "hans@ytopp-gluecklich.kim.telematik"
+            }
+          }
+        ],
+        "reasonCode": [
+          {
+            "coding": [
+              {
+                "code": "medication-runs-out",
+                "system": "https://gematik.de/fhir/erp-servicerequest/CodeSystem/medication-request-reason-cs"
+              }
+            ]
+          }
+        ],
+        "reasonReference": [
+          {
+            "reference": "Observation/Medication-Runs-Out-Example-dateTime"
+          },
+          {
+            "reference": "Observation/Medication-Runs-Out-Example-Quantity"
+          }
+        ],
+        "note": [
+          {
+            "text": "Medikament läuft am 31.01.2023 aus. Es sind noch 7 stk übrig. "
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl": "http://erp-servicerequest-test.de/MedicationRequest/Example-Initial-Medication-Request",
+      "resource": {
+        "resourceType": "MedicationRequest",
+        "id": "Example-Initial-Medication-Request",
+        "meta": {
+          "profile": [
+            "https://gematik.de/fhir/erp-servicerequest/StructureDefinition/erp-service-request-medication-request"
+          ]
+        },
+        "extension": [
+          {
+            "valueIdentifier": {
+              "system": "https://gematik.de/fhir/erp/NamingSystem/GEM_ERP_NS_PrescriptionId",
+              "value": "160.100.000.000.001.36"
+            },
+            "url": "https://gematik.de/fhir/erp-servicerequest/StructureDefinition/prescription-id-ex"
+          }
+        ],
+        "dispenseRequest": {
+          "quantity": {
+            "system": "http://unitsofmeasure.org",
+            "code": "{Package}",
+            "value": 1
+          }
+        },
+        "status": "active",
+        "intent": "order",
+        "medicationReference": {
+          "reference": "Medication/Example-Initial-Medication"
+        },
+        "subject": {
+          "reference": "Patient/Example-Patient"
+        },
+        "authoredOn": "2022-05-20",
+        "dosageInstruction": [
+          {
+            "text": "2mal tägl. 5ml"
+          }
+        ],
+        "substitution": {
+          "allowedBoolean": true
+        }
+      }
+    },
+    {
+      "fullUrl": "http://erp-servicerequest-test.de/Medication/Example-Initial-Medication",
+      "resource": {
+        "resourceType": "Medication",
+        "id": "Example-Initial-Medication",
+        "meta": {
+          "profile": [
+            "https://fhir.kbv.de/StructureDefinition/KBV_PR_ERP_Medication_PZN|1.1.0"
+          ]
+        },
+        "extension": [
+          {
+            "url": "https://fhir.kbv.de/StructureDefinition/KBV_EX_Base_Medication_Type",
+            "valueCodeableConcept": {
+              "coding": [
+                {
+                  "system": "http://snomed.info/sct",
+                  "version": "http://snomed.info/sct/900000000000207008/version/20220331",
+                  "code": "763158003",
+                  "display": "Medicinal product (product)"
+                }
+              ]
+            }
+          },
+          {
+            "url": "https://fhir.kbv.de/StructureDefinition/KBV_EX_ERP_Medication_Category",
+            "valueCoding": {
+              "code": "00",
+              "system": "https://fhir.kbv.de/CodeSystem/KBV_CS_ERP_Medication_Category"
+            }
+          },
+          {
+            "url": "https://fhir.kbv.de/StructureDefinition/KBV_EX_ERP_Medication_Vaccine",
+            "valueBoolean": false
+          },
+          {
+            "url": "http://fhir.de/StructureDefinition/normgroesse",
+            "valueCode": "N1"
+          }
+        ],
+        "code": {
+          "coding": [
+            {
+              "system": "http://fhir.de/CodeSystem/ifa/pzn",
+              "code": "08585997"
+            }
+          ],
+          "text": "Prospan® Hustensaft 100ml"
+        },
+        "form": {
+          "coding": [
+            {
+              "system": "https://fhir.kbv.de/CodeSystem/KBV_CS_SFHIR_KBV_DARREICHUNGSFORM",
+              "code": "FLE"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "fullUrl": "http://erp-servicerequest-test.de/Patient/Example-Patient",
+      "resource": {
+        "resourceType": "Patient",
+        "id": "Example-Patient",
+        "meta": {
+          "profile": [
+            "https://fhir.kbv.de/StructureDefinition/KBV_PR_FOR_Patient|1.1.0"
+          ]
+        },
+        "identifier": [
+          {
+            "type": {
+              "coding": [
+                {
+                  "system": "http://fhir.de/CodeSystem/identifier-type-de-basis",
+                  "code": "GKV"
+                }
+              ]
+            },
+            "system": "http://fhir.de/sid/gkv/kvid-10",
+            "value": "X234567890"
+          }
+        ],
+        "name": [
+          {
+            "use": "official",
+            "family": "Königsstein",
+            "_family": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/humanname-own-name",
+                  "valueString": "Königsstein"
+                }
+              ]
+            },
+            "given": [
+              "Ludger"
+            ]
+          }
+        ],
+        "address": [
+          {
+            "type": "both",
+            "line": [
+              "Musterstr. 1"
+            ],
+            "_line": [
+              {
+                "extension": [
+                  {
+                    "url": "http://hl7.org/fhir/StructureDefinition/iso21090-ADXP-houseNumber",
+                    "valueString": "1"
+                  },
+                  {
+                    "url": "http://hl7.org/fhir/StructureDefinition/iso21090-ADXP-streetName",
+                    "valueString": "Musterstr."
+                  }
+                ]
+              }
+            ],
+            "city": "Berlin",
+            "postalCode": "10623"
+          }
+        ],
+        "birthDate": "1935-06-22"
+      }
+    },
+    {
+      "fullUrl": "http://erp-servicerequest-test.de/Organization/Example-HealthCareService-Organization",
+      "resource": {
+        "resourceType": "Organization",
+        "id": "Example-HealthCareService-Organization",
+        "meta": {
+          "profile": [
+            "https://gematik.de/fhir/erp-servicerequest/StructureDefinition/erp-service-request-organization"
+          ]
+        },
+        "identifier": [
+          {
+            "type": {
+              "coding": [
+                {
+                  "code": "kim-2.0",
+                  "system": "https://gematik.de/fhir/directory/CodeSystem/EndpointDirectoryConnectionType"
+                }
+              ]
+            },
+            "system": "http://gematik.de/fhir/sid/KIM-Adresse",
+            "value": "pflegeheim.immergrün.arzt@sana-pflegeheime.kim.telematik"
+          },
+          {
+            "type": {
+              "coding": [
+                {
+                  "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
+                  "code": "PRN"
+                }
+              ]
+            },
+            "system": "https://gematik.de/fhir/sid/telematik-id",
+            "value": "1-031234567"
+          },
+          {
+            "type": {
+              "coding": [
+                {
+                  "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
+                  "code": "BSNR"
+                }
+              ]
+            },
+            "system": "https://fhir.kbv.de/NamingSystem/KBV_NS_Base_BSNR",
+            "value": "031234567"
+          }
+        ],
+        "address": [
+          {
+            "type": "both",
+            "line": [
+              "Musterstr. 2"
+            ],
+            "_line": [
+              {
+                "extension": [
+                  {
+                    "url": "http://hl7.org/fhir/StructureDefinition/iso21090-ADXP-houseNumber",
+                    "valueString": "2"
+                  },
+                  {
+                    "url": "http://hl7.org/fhir/StructureDefinition/iso21090-ADXP-streetName",
+                    "valueString": "Musterstr."
+                  }
+                ]
+              }
+            ],
+            "city": "Berlin",
+            "postalCode": "10623"
+          }
+        ],
+        "name": "Pflegeheim Immergrün",
+        "telecom": [
+          {
+            "system": "phone",
+            "value": "0301234567"
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl": "http://erp-servicerequest-test.de/Observation/Medication-Runs-Out-Example-dateTime",
+      "resource": {
+        "resourceType": "Observation",
+        "id": "Medication-Runs-Out-Example-dateTime",
+        "meta": {
+          "profile": [
+            "https://gematik.de/fhir/erp-servicerequest/StructureDefinition/erp-service-request-remaining-medication"
+          ]
+        },
+        "status": "final",
+        "subject": {
+          "reference": "Patient/Example-Patient"
+        },
+        "code": {
+          "coding": [
+            {
+              "code": "range-of-medication",
+              "system": "https://gematik.de/fhir/erp-servicerequest/CodeSystem/medication-observation-cs"
+            }
+          ]
+        },
+        "valueDateTime": "2023-01-31"
+      }
+    },
+    {
+      "fullUrl": "http://erp-servicerequest-test.de/Observation/Medication-Runs-Out-Example-Quantity",
+      "resource": {
+        "resourceType": "Observation",
+        "id": "Medication-Runs-Out-Example-Quantity",
+        "meta": {
+          "profile": [
+            "https://gematik.de/fhir/erp-servicerequest/StructureDefinition/erp-service-request-remaining-medication"
+          ]
+        },
+        "status": "final",
+        "subject": {
+          "reference": "Patient/Example-Patient"
+        },
+        "code": {
+          "coding": [
+            {
+              "code": "range-of-medication",
+              "system": "https://gematik.de/fhir/erp-servicerequest/CodeSystem/medication-observation-cs"
+            }
+          ]
+        },
+        "valueQuantity": {
+          "value": 7,
+          "unit": "stk"
+        }
+      }
+    }
+  ]
+}

--- a/examples/zyto/fulfilled-prescription-request/Bundle-UC4-2-Prescription-Request-To-Pharmacy.json
+++ b/examples/zyto/fulfilled-prescription-request/Bundle-UC4-2-Prescription-Request-To-Pharmacy.json
@@ -1,0 +1,593 @@
+{
+  "resourceType": "Bundle",
+  "id": "UC4-2-Prescription-Request-To-Pharmacy",
+  "meta": {
+    "profile": [
+      "https://gematik.de/fhir/erp-servicerequest/StructureDefinition/erp-service-request-message-container"
+    ]
+  },
+  "type": "message",
+  "identifier": {
+    "system": "urn:ietf:rfc:3986",
+    "value": "urn:uuid:c80f6c55-92f8-4518-ba66-cb193da09336"
+  },
+  "timestamp": "2023-02-01T13:28:17.239+02:00",
+  "entry": [
+    {
+      "fullUrl": "http://erp-servicerequest-test.de/MessageHeader/UC4-2-Practitioner-to-Pharmacy-MessageHeader",
+      "resource": {
+        "resourceType": "MessageHeader",
+        "id": "UC4-2-Practitioner-to-Pharmacy-MessageHeader",
+        "meta": {
+          "profile": [
+            "https://gematik.de/fhir/erp-servicerequest/StructureDefinition/erp-service-request-request-header"
+          ]
+        },
+        "focus": [
+          {
+            "reference": "ServiceRequest/UC4-Response-Prescription-Request"
+          }
+        ],
+        "sender": {
+          "identifier": {
+            "system": "http://gematik.de/fhir/sid/KIM-Adresse",
+            "value": "hans@ytopp-gluecklich.kim.telematik"
+          },
+          "display": "Praxis Hans Topp-Glücklich"
+        },
+        "source": {
+          "name": "Practitioner-Source",
+          "software": "Practitioner-Software",
+          "version": "1.0.0",
+          "contact": {
+            "system": "email",
+            "value": "info@practitioner.email"
+          },
+          "endpoint": "http://practitioner.endpoint"
+        },
+        "destination": [
+          {
+            "receiver": {
+              "identifier": {
+                "system": "http://gematik.de/fhir/sid/KIM-Adresse",
+                "value": "arbeitsplatz-1@test-apotheke.kim.telematik"
+              },
+              "display": "Test Apotheke"
+            },
+            "endpoint": "http://test-apotheke.de"
+          }
+        ],
+        "eventCoding": {
+          "code": "eRezept_ParenteraleZubereitung;Rezeptbestaetigung",
+          "system": "https://gematik.de/fhir/atf/CodeSystem/service-identifier-cs"
+        }
+      }
+    },
+    {
+      "fullUrl": "http://erp-servicerequest-test.de/ServiceRequest/UC4-Response-Prescription-Request",
+      "resource": {
+        "resourceType": "ServiceRequest",
+        "id": "UC4-Response-Prescription-Request",
+        "meta": {
+          "profile": [
+            "https://gematik.de/fhir/erp-servicerequest/StructureDefinition/erp-service-request-prescription-request"
+          ]
+        },
+        "intent": "order",
+        "requisition": {
+          "system": "https://gematik.de/fhir/erp-servicerequest/sid/NamingSystemProcedureIdentifier",
+          "value": "GroupID-UC4"
+        },
+        "extension": [
+          {
+            "valueIdentifier": {
+              "system": "https://gematik.de/fhir/erp/sid/NamingSystemEPrescriptionToken",
+              "value": "Task/160.100.000.000.004.36/$accept?ac=777bea0e13cc9c42ceec14aec3ddee2263325dc2c6c699db115f58fe423607ea"
+            },
+            "url": "https://gematik.de/fhir/erp-servicerequest/StructureDefinition/eprescription-token-ex"
+          }
+        ],
+        "code": {
+          "coding": [
+            {
+              "code": "prescription-request",
+              "system": "https://gematik.de/fhir/erp-servicerequest/CodeSystem/service-request-type-cs"
+            }
+          ]
+        },
+        "identifier": [
+          {
+            "system": "https://gematik.de/fhir/erp-servicerequest/sid/NamingSystemRequestIdentifier",
+            "value": "1"
+          },
+          {
+            "system": "https://gematik.de/fhir/erp-servicerequest/sid/patient-id",
+            "value": "Patient-ID-e15232e9-01e0-4ce8-b628-71adb9023b21"
+          },
+          {
+            "system": "https://gematik.de/fhir/erp-servicerequest/sid/case-id",
+            "value": "Case-ID-85d39ff7-2f02-4bfc-85d5-0ba2752f6076"
+          },
+          {
+            "system": "https://gematik.de/fhir/erp-servicerequest/sid/process-id",
+            "value": "Process-ID-db6fd21d-cc85-4411-8567-479a7dc1ef74"
+          },
+          {
+            "system": "https://my-very-own-zyto-identifier",
+            "value": "My-ID-bdbdf8a1-ffa4-4f16-a6c4-38e690ac5548"
+          }
+        ],
+        "basedOn": [
+          {
+            "reference": "MedicationRequest/Example-Response-KBV-Prescription"
+          }
+        ],
+        "status": "completed",
+        "subject": {
+          "reference": "Patient/Example-Patient"
+        },
+        "orderDetail": [
+          {
+            "coding": [
+              {
+                "code": "return-to-requester",
+                "system": "https://gematik.de/fhir/erp-servicerequest/CodeSystem/prescription-fullfillment-type-cs"
+              }
+            ]
+          }
+        ],
+        "occurrenceDateTime": "2023-01-30",
+        "authoredOn": "2023-01-27",
+        "requester": {
+          "reference": "Organization/Example-Pharmacy-Organization"
+        },
+        "performer": [
+          {
+            "reference": "Practitioner/Example-Practitioner"
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl": "http://erp-servicerequest-test.de/MedicationRequest/Example-Response-KBV-Prescription",
+      "resource": {
+        "resourceType": "MedicationRequest",
+        "id": "Example-Response-KBV-Prescription",
+        "meta": {
+          "profile": [
+            "https://fhir.kbv.de/StructureDefinition/KBV_PR_ERP_Prescription|1.1.0"
+          ]
+        },
+        "status": "active",
+        "intent": "order",
+        "extension": [
+          {
+            "url": "https://fhir.kbv.de/StructureDefinition/KBV_EX_ERP_EmergencyServicesFee",
+            "valueBoolean": false
+          },
+          {
+            "url": "https://fhir.kbv.de/StructureDefinition/KBV_EX_ERP_BVG",
+            "valueBoolean": false
+          },
+          {
+            "url": "https://fhir.kbv.de/StructureDefinition/KBV_EX_ERP_Multiple_Prescription",
+            "extension": [
+              {
+                "url": "Kennzeichen",
+                "valueBoolean": false
+              }
+            ]
+          },
+          {
+            "url": "https://fhir.kbv.de/StructureDefinition/KBV_EX_FOR_StatusCoPayment",
+            "valueCoding": {
+              "code": "1",
+              "system": "https://fhir.kbv.de/CodeSystem/KBV_CS_FOR_StatusCoPayment"
+            }
+          }
+        ],
+        "dispenseRequest": {
+          "quantity": {
+            "system": "http://unitsofmeasure.org",
+            "code": "{Package}",
+            "value": 1
+          }
+        },
+        "dosageInstruction": [
+          {
+            "extension": [
+              {
+                "url": "https://fhir.kbv.de/StructureDefinition/KBV_EX_ERP_DosageFlag",
+                "valueBoolean": true
+              }
+            ],
+            "text": "2mal tägl. 5ml"
+          }
+        ],
+        "medicationReference": {
+          "reference": "Medication/Example-Response-Medication"
+        },
+        "subject": {
+          "reference": "Patient/Example-Patient"
+        },
+        "authoredOn": "2022-05-20",
+        "requester": {
+          "reference": "Practitioner/Example-Practitioner"
+        },
+        "insurance": [
+          {
+            "reference": "Coverage/Response-Coverage"
+          }
+        ],
+        "substitution": {
+          "allowedBoolean": true
+        }
+      }
+    },
+    {
+      "fullUrl": "http://erp-servicerequest-test.de/Medication/Example-Response-Medication",
+      "resource": {
+        "resourceType": "Medication",
+        "id": "Example-Response-Medication",
+        "meta": {
+          "profile": [
+            "https://fhir.kbv.de/StructureDefinition/KBV_PR_ERP_Medication_PZN|1.1.0"
+          ]
+        },
+        "extension": [
+          {
+            "url": "https://fhir.kbv.de/StructureDefinition/KBV_EX_Base_Medication_Type",
+            "valueCodeableConcept": {
+              "coding": [
+                {
+                  "system": "http://snomed.info/sct",
+                  "version": "http://snomed.info/sct/900000000000207008/version/20220331",
+                  "code": "763158003",
+                  "display": "Medicinal product (product)"
+                }
+              ]
+            }
+          },
+          {
+            "url": "https://fhir.kbv.de/StructureDefinition/KBV_EX_ERP_Medication_Category",
+            "valueCoding": {
+              "code": "00",
+              "system": "https://fhir.kbv.de/CodeSystem/KBV_CS_ERP_Medication_Category"
+            }
+          },
+          {
+            "url": "https://fhir.kbv.de/StructureDefinition/KBV_EX_ERP_Medication_Vaccine",
+            "valueBoolean": false
+          },
+          {
+            "url": "http://fhir.de/StructureDefinition/normgroesse",
+            "valueCode": "N1"
+          }
+        ],
+        "code": {
+          "coding": [
+            {
+              "system": "http://fhir.de/CodeSystem/ifa/pzn",
+              "code": "08585997"
+            }
+          ],
+          "text": "Prospan® Hustensaft 100ml N1"
+        },
+        "form": {
+          "coding": [
+            {
+              "system": "https://fhir.kbv.de/CodeSystem/KBV_CS_SFHIR_KBV_DARREICHUNGSFORM",
+              "code": "FLE"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "fullUrl": "http://erp-servicerequest-test.de/Coverage/Response-Coverage",
+      "resource": {
+        "resourceType": "Coverage",
+        "id": "Response-Coverage",
+        "meta": {
+          "profile": [
+            "https://fhir.kbv.de/StructureDefinition/KBV_PR_FOR_Coverage|1.1.0"
+          ]
+        },
+        "status": "active",
+        "payor": [
+          {
+            "identifier": {
+              "system": "http://fhir.de/sid/arge-ik/iknr",
+              "value": "108416214"
+            },
+            "display": "AOK Bayern Die Gesundh."
+          }
+        ],
+        "extension": [
+          {
+            "url": "http://fhir.de/StructureDefinition/gkv/besondere-personengruppe",
+            "valueCoding": {
+              "code": "00",
+              "system": "https://fhir.kbv.de/CodeSystem/KBV_CS_SFHIR_KBV_PERSONENGRUPPE"
+            }
+          },
+          {
+            "url": "http://fhir.de/StructureDefinition/gkv/dmp-kennzeichen",
+            "valueCoding": {
+              "code": "00",
+              "system": "https://fhir.kbv.de/CodeSystem/KBV_CS_SFHIR_KBV_DMP"
+            }
+          },
+          {
+            "url": "http://fhir.de/StructureDefinition/gkv/wop",
+            "valueCoding": {
+              "code": "72",
+              "system": "https://fhir.kbv.de/CodeSystem/KBV_CS_SFHIR_ITA_WOP"
+            }
+          },
+          {
+            "url": "http://fhir.de/StructureDefinition/gkv/versichertenart",
+            "valueCoding": {
+              "code": "3",
+              "system": "https://fhir.kbv.de/CodeSystem/KBV_CS_SFHIR_KBV_VERSICHERTENSTATUS"
+            }
+          }
+        ],
+        "type": {
+          "coding": [
+            {
+              "code": "GKV",
+              "system": "http://fhir.de/CodeSystem/versicherungsart-de-basis"
+            }
+          ]
+        },
+        "beneficiary": {
+          "reference": "Patient/Example-Patient"
+        },
+        "period": {
+          "end": "2040-04-01"
+        }
+      }
+    },
+    {
+      "fullUrl": "http://erp-servicerequest-test.de/Patient/Example-Patient",
+      "resource": {
+        "resourceType": "Patient",
+        "id": "Example-Patient",
+        "meta": {
+          "profile": [
+            "https://fhir.kbv.de/StructureDefinition/KBV_PR_FOR_Patient|1.1.0"
+          ]
+        },
+        "identifier": [
+          {
+            "type": {
+              "coding": [
+                {
+                  "system": "http://fhir.de/CodeSystem/identifier-type-de-basis",
+                  "code": "GKV"
+                }
+              ]
+            },
+            "system": "http://fhir.de/sid/gkv/kvid-10",
+            "value": "X234567890"
+          }
+        ],
+        "name": [
+          {
+            "use": "official",
+            "family": "Königsstein",
+            "_family": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/humanname-own-name",
+                  "valueString": "Königsstein"
+                }
+              ]
+            },
+            "given": [
+              "Ludger"
+            ]
+          }
+        ],
+        "address": [
+          {
+            "type": "both",
+            "line": [
+              "Musterstr. 1"
+            ],
+            "_line": [
+              {
+                "extension": [
+                  {
+                    "url": "http://hl7.org/fhir/StructureDefinition/iso21090-ADXP-houseNumber",
+                    "valueString": "1"
+                  },
+                  {
+                    "url": "http://hl7.org/fhir/StructureDefinition/iso21090-ADXP-streetName",
+                    "valueString": "Musterstr."
+                  }
+                ]
+              }
+            ],
+            "city": "Berlin",
+            "postalCode": "10623"
+          }
+        ],
+        "birthDate": "1935-06-22"
+      }
+    },
+    {
+      "fullUrl": "http://erp-servicerequest-test.de/Practitioner/Example-Practitioner",
+      "resource": {
+        "resourceType": "Practitioner",
+        "id": "Example-Practitioner",
+        "meta": {
+          "profile": [
+            "https://fhir.kbv.de/StructureDefinition/KBV_PR_FOR_Practitioner|1.1.0"
+          ]
+        },
+        "name": [
+          {
+            "use": "official",
+            "prefix": [
+              "Dr. med."
+            ],
+            "_prefix": [
+              {
+                "extension": [
+                  {
+                    "url": "http://hl7.org/fhir/StructureDefinition/iso21090-EN-qualifier",
+                    "valueCode": "AC"
+                  }
+                ]
+              }
+            ],
+            "family": "Topp-Glücklich",
+            "_family": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/humanname-own-name",
+                  "valueString": "Topp-Glücklich"
+                }
+              ]
+            },
+            "given": [
+              "Hans"
+            ]
+          }
+        ],
+        "qualification": [
+          {
+            "code": {
+              "coding": [
+                {
+                  "system": "https://fhir.kbv.de/CodeSystem/KBV_CS_FOR_Qualification_Type",
+                  "code": "00"
+                }
+              ]
+            }
+          },
+          {
+            "code": {
+              "coding": [
+                {
+                  "system": "https://fhir.kbv.de/CodeSystem/KBV_CS_FOR_Berufsbezeichnung",
+                  "code": "Berufsbezeichnung"
+                }
+              ],
+              "text": "Hausarzt"
+            }
+          }
+        ],
+        "identifier": [
+          {
+            "type": {
+              "coding": [
+                {
+                  "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
+                  "code": "LANR"
+                }
+              ]
+            },
+            "system": "https://fhir.kbv.de/NamingSystem/KBV_NS_Base_ANR",
+            "value": "838382202"
+          },
+          {
+            "type": {
+              "coding": [
+                {
+                  "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
+                  "code": "PRN"
+                }
+              ]
+            },
+            "system": "https://gematik.de/fhir/sid/telematik-id",
+            "value": "1-838382202"
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl": "http://erp-servicerequest-test.de/Organization/Example-Pharmacy-Organization",
+      "resource": {
+        "resourceType": "Organization",
+        "id": "Example-Pharmacy-Organization",
+        "meta": {
+          "profile": [
+            "https://gematik.de/fhir/erp-servicerequest/StructureDefinition/erp-service-request-organization"
+          ]
+        },
+        "identifier": [
+          {
+            "type": {
+              "coding": [
+                {
+                  "code": "kim-2.0",
+                  "system": "https://gematik.de/fhir/directory/CodeSystem/EndpointDirectoryConnectionType"
+                }
+              ]
+            },
+            "system": "http://gematik.de/fhir/sid/KIM-Adresse",
+            "value": "arbeitsplatz-1@test-apotheke.kim.telematik"
+          },
+          {
+            "type": {
+              "coding": [
+                {
+                  "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
+                  "code": "PRN"
+                }
+              ]
+            },
+            "system": "https://gematik.de/fhir/sid/telematik-id",
+            "value": "1-57634852"
+          },
+          {
+            "type": {
+              "coding": [
+                {
+                  "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
+                  "code": "BSNR"
+                }
+              ]
+            },
+            "system": "https://fhir.kbv.de/NamingSystem/KBV_NS_Base_BSNR",
+            "value": "581463872"
+          }
+        ],
+        "address": [
+          {
+            "type": "both",
+            "line": [
+              "Musterstr. 2"
+            ],
+            "_line": [
+              {
+                "extension": [
+                  {
+                    "url": "http://hl7.org/fhir/StructureDefinition/iso21090-ADXP-houseNumber",
+                    "valueString": "2"
+                  },
+                  {
+                    "url": "http://hl7.org/fhir/StructureDefinition/iso21090-ADXP-streetName",
+                    "valueString": "Musterstr."
+                  }
+                ]
+              }
+            ],
+            "city": "Berlin",
+            "postalCode": "10623"
+          }
+        ],
+        "name": "Test Apotheke",
+        "telecom": [
+          {
+            "system": "phone",
+            "value": "0301234567"
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/examples/zyto/prescription-request/Bundle-UC4-1-Prescription-and-Dispense-Request-To-Prescriber.json
+++ b/examples/zyto/prescription-request/Bundle-UC4-1-Prescription-and-Dispense-Request-To-Prescriber.json
@@ -1,0 +1,412 @@
+{
+  "resourceType": "Bundle",
+  "id": "UC4-1-Prescription-and-Dispense-Request-To-Prescriber",
+  "meta": {
+    "profile": [
+      "https://gematik.de/fhir/erp-servicerequest/StructureDefinition/erp-service-request-message-container"
+    ]
+  },
+  "type": "message",
+  "identifier": {
+    "system": "urn:ietf:rfc:3986",
+    "value": "urn:uuid:29888885-6639-481c-934e-4b7b51745084"
+  },
+  "timestamp": "2015-02-07T13:28:17.239+02:00",
+  "entry": [
+    {
+      "fullUrl": "http://erp-servicerequest-test.de/MessageHeader/UC4-1-Pharmacy-to-Practitioner-MessageHeader",
+      "resource": {
+        "resourceType": "MessageHeader",
+        "id": "UC4-1-Pharmacy-to-Practitioner-MessageHeader",
+        "meta": {
+          "profile": [
+            "https://gematik.de/fhir/erp-servicerequest/StructureDefinition/erp-service-request-request-header"
+          ]
+        },
+        "focus": [
+          {
+            "reference": "ServiceRequest/UC4-Initial-Prescription-Request"
+          }
+        ],
+        "sender": {
+          "identifier": {
+            "system": "http://gematik.de/fhir/sid/KIM-Adresse",
+            "value": "arbeitsplatz-1@test-apotheke.kim.telematik"
+          },
+          "display": "Test Apotheke"
+        },
+        "source": {
+          "name": "Pharmacy-Source",
+          "software": "Pharmacy-Software",
+          "version": "1.0.0",
+          "contact": {
+            "system": "email",
+            "value": "info@pharmacy.email"
+          },
+          "endpoint": "http://pharmacy.endpoint"
+        },
+        "destination": [
+          {
+            "receiver": {
+              "identifier": {
+                "system": "http://gematik.de/fhir/sid/KIM-Adresse",
+                "value": "hans@ytopp-gluecklich.kim.telematik"
+              },
+              "display": "Praxis Hans Topp-Glücklich"
+            },
+            "endpoint": "klaus@test.de"
+          }
+        ],
+        "eventCoding": {
+          "code": "eRezept_ParenteraleZubereitung;Rezeptanfrage",
+          "system": "https://gematik.de/fhir/atf/CodeSystem/service-identifier-cs"
+        }
+      }
+    },
+    {
+      "fullUrl": "http://erp-servicerequest-test.de/Patient/Example-Patient",
+      "resource": {
+        "resourceType": "Patient",
+        "id": "Example-Patient",
+        "meta": {
+          "profile": [
+            "https://fhir.kbv.de/StructureDefinition/KBV_PR_FOR_Patient|1.1.0"
+          ]
+        },
+        "identifier": [
+          {
+            "type": {
+              "coding": [
+                {
+                  "system": "http://fhir.de/CodeSystem/identifier-type-de-basis",
+                  "code": "GKV"
+                }
+              ]
+            },
+            "system": "http://fhir.de/sid/gkv/kvid-10",
+            "value": "X234567890"
+          }
+        ],
+        "name": [
+          {
+            "use": "official",
+            "family": "Königsstein",
+            "_family": {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/humanname-own-name",
+                  "valueString": "Königsstein"
+                }
+              ]
+            },
+            "given": [
+              "Ludger"
+            ]
+          }
+        ],
+        "address": [
+          {
+            "type": "both",
+            "line": [
+              "Musterstr. 1"
+            ],
+            "_line": [
+              {
+                "extension": [
+                  {
+                    "url": "http://hl7.org/fhir/StructureDefinition/iso21090-ADXP-houseNumber",
+                    "valueString": "1"
+                  },
+                  {
+                    "url": "http://hl7.org/fhir/StructureDefinition/iso21090-ADXP-streetName",
+                    "valueString": "Musterstr."
+                  }
+                ]
+              }
+            ],
+            "city": "Berlin",
+            "postalCode": "10623"
+          }
+        ],
+        "birthDate": "1935-06-22"
+      }
+    },
+    {
+      "fullUrl": "http://erp-servicerequest-test.de/ServiceRequest/UC4-Initial-Prescription-Request",
+      "resource": {
+        "resourceType": "ServiceRequest",
+        "id": "UC4-Initial-Prescription-Request",
+        "meta": {
+          "profile": [
+            "https://gematik.de/fhir/erp-servicerequest/StructureDefinition/erp-service-request-prescription-request"
+          ]
+        },
+        "intent": "order",
+        "requisition": {
+          "system": "https://gematik.de/fhir/erp-servicerequest/sid/NamingSystemProcedureIdentifier",
+          "value": "GroupID-UC4"
+        },
+        "code": {
+          "coding": [
+            {
+              "code": "prescription-request",
+              "system": "https://gematik.de/fhir/erp-servicerequest/CodeSystem/service-request-type-cs"
+            }
+          ]
+        },
+        "identifier": [
+          {
+            "system": "https://gematik.de/fhir/erp-servicerequest/sid/NamingSystemRequestIdentifier",
+            "value": "1"
+          },
+          {
+            "system": "https://gematik.de/fhir/erp-servicerequest/sid/patient-id",
+            "value": "Patient-ID-e15232e9-01e0-4ce8-b628-71adb9023b21"
+          },
+          {
+            "system": "https://gematik.de/fhir/erp-servicerequest/sid/case-id",
+            "value": "Case-ID-85d39ff7-2f02-4bfc-85d5-0ba2752f6076"
+          },
+          {
+            "system": "https://gematik.de/fhir/erp-servicerequest/sid/process-id",
+            "value": "Process-ID-db6fd21d-cc85-4411-8567-479a7dc1ef74"
+          },
+          {
+            "system": "https://my-very-own-zyto-identifier",
+            "value": "My-ID-bdbdf8a1-ffa4-4f16-a6c4-38e690ac5548"
+          }
+        ],
+        "basedOn": [
+          {
+            "reference": "MedicationRequest/Example-Zyto-Medication-Request"
+          }
+        ],
+        "status": "active",
+        "subject": {
+          "reference": "Patient/Example-Patient"
+        },
+        "orderDetail": [
+          {
+            "coding": [
+              {
+                "code": "return-to-requester",
+                "system": "https://gematik.de/fhir/erp-servicerequest/CodeSystem/prescription-fullfillment-type-cs"
+              }
+            ]
+          }
+        ],
+        "occurrenceDateTime": "2023-02-01",
+        "authoredOn": "2023-01-27",
+        "requester": {
+          "reference": "Organization/Example-Pharmacy-Organization"
+        },
+        "performer": [
+          {
+            "identifier": {
+              "system": "http://gematik.de/fhir/sid/KIM-Adresse",
+              "value": "hans@ytopp-gluecklich.kim.telematik"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl": "http://erp-servicerequest-test.de/MedicationRequest/Example-Zyto-Medication-Request",
+      "resource": {
+        "resourceType": "MedicationRequest",
+        "id": "Example-Zyto-Medication-Request",
+        "meta": {
+          "profile": [
+            "https://gematik.de/fhir/erp-servicerequest/StructureDefinition/erp-service-request-medication-request"
+          ]
+        },
+        "status": "active",
+        "intent": "order",
+        "medicationReference": {
+          "reference": "Medication/Example-Zyto-Medication"
+        },
+        "subject": {
+          "reference": "Patient/Example-Patient"
+        },
+        "authoredOn": "2022-05-20",
+        "substitution": {
+          "allowedBoolean": false
+        }
+      }
+    },
+    {
+      "fullUrl": "http://erp-servicerequest-test.de/Medication/Example-Zyto-Medication",
+      "resource": {
+        "resourceType": "Medication",
+        "id": "Example-Zyto-Medication",
+        "meta": {
+          "profile": [
+            "https://fhir.kbv.de/StructureDefinition/KBV_PR_ERP_Medication_Compounding|1.1.0"
+          ]
+        },
+        "extension": [
+          {
+            "url": "https://fhir.kbv.de/StructureDefinition/KBV_EX_Base_Medication_Type",
+            "valueCodeableConcept": {
+              "coding": [
+                {
+                  "system": "http://snomed.info/sct",
+                  "version": "http://snomed.info/sct/900000000000207008/version/20220331",
+                  "code": "373873005:860781008=362943005",
+                  "display": "Pharmaceutical / biologic product (product) : Has product characteristic (attribute) = Manual method (qualifier value)"
+                }
+              ]
+            }
+          },
+          {
+            "url": "https://fhir.kbv.de/StructureDefinition/KBV_EX_ERP_Medication_Category",
+            "valueCoding": {
+              "code": "00",
+              "system": "https://fhir.kbv.de/CodeSystem/KBV_CS_ERP_Medication_Category"
+            }
+          },
+          {
+            "url": "https://fhir.kbv.de/StructureDefinition/KBV_EX_ERP_Medication_Vaccine",
+            "valueBoolean": false
+          }
+        ],
+        "code": {
+          "coding": [
+            {
+              "system": "https://fhir.kbv.de/CodeSystem/KBV_CS_ERP_Medication_Type",
+              "code": "rezeptur"
+            }
+          ]
+        },
+        "amount": {
+          "denominator": {
+            "value": 1
+          },
+          "numerator": {
+            "extension": [
+              {
+                "url": "https://fhir.kbv.de/StructureDefinition/KBV_EX_ERP_Medication_PackagingSize",
+                "valueString": "500"
+              }
+            ],
+            "unit": "ml"
+          }
+        },
+        "ingredient": [
+          {
+            "strength": {
+              "denominator": {
+                "value": 1
+              },
+              "numerator": {
+                "value": 180,
+                "unit": "mg"
+              }
+            },
+            "itemCodeableConcept": {
+              "text": "Etoposid"
+            }
+          },
+          {
+            "strength": {
+              "denominator": {
+                "value": 1
+              },
+              "numerator": {
+                "value": 500,
+                "unit": "ml"
+              }
+            },
+            "itemCodeableConcept": {
+              "text": "NaCl 0,9 %"
+            }
+          }
+        ],
+        "form": {
+          "text": "Infusionslösung"
+        }
+      }
+    },
+    {
+      "fullUrl": "http://erp-servicerequest-test.de/Organization/Example-Pharmacy-Organization",
+      "resource": {
+        "resourceType": "Organization",
+        "id": "Example-Pharmacy-Organization",
+        "meta": {
+          "profile": [
+            "https://gematik.de/fhir/erp-servicerequest/StructureDefinition/erp-service-request-organization"
+          ]
+        },
+        "identifier": [
+          {
+            "type": {
+              "coding": [
+                {
+                  "code": "kim-2.0",
+                  "system": "https://gematik.de/fhir/directory/CodeSystem/EndpointDirectoryConnectionType"
+                }
+              ]
+            },
+            "system": "http://gematik.de/fhir/sid/KIM-Adresse",
+            "value": "arbeitsplatz-1@test-apotheke.kim.telematik"
+          },
+          {
+            "type": {
+              "coding": [
+                {
+                  "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
+                  "code": "PRN"
+                }
+              ]
+            },
+            "system": "https://gematik.de/fhir/sid/telematik-id",
+            "value": "1-57634852"
+          },
+          {
+            "type": {
+              "coding": [
+                {
+                  "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
+                  "code": "BSNR"
+                }
+              ]
+            },
+            "system": "https://fhir.kbv.de/NamingSystem/KBV_NS_Base_BSNR",
+            "value": "581463872"
+          }
+        ],
+        "address": [
+          {
+            "type": "both",
+            "line": [
+              "Musterstr. 2"
+            ],
+            "_line": [
+              {
+                "extension": [
+                  {
+                    "url": "http://hl7.org/fhir/StructureDefinition/iso21090-ADXP-houseNumber",
+                    "valueString": "2"
+                  },
+                  {
+                    "url": "http://hl7.org/fhir/StructureDefinition/iso21090-ADXP-streetName",
+                    "valueString": "Musterstr."
+                  }
+                ]
+              }
+            ],
+            "city": "Berlin",
+            "postalCode": "10623"
+          }
+        ],
+        "name": "Test Apotheke",
+        "telecom": [
+          {
+            "system": "phone",
+            "value": "0301234567"
+          }
+        ]
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Hersteller haben gewünscht, dass es möglich sein soll Beispiele in das Repository einzugeben.
Mit diesem PR werden die Strukturen vorgegeben und entsprechende Beispiele bereitgestellt.
