### PR TITLE
Add .dependencyLicenses file for license checks exclusion

### DIFF
--- a/.dependencyLicenses
+++ b/.dependencyLicenses
@@ -1,0 +1,1 @@
+./input/content/assets/js/heading-links.js


### PR DESCRIPTION
Introduce a .dependencyLicenses file to specify files that should be excluded from license checks.